### PR TITLE
fix:  3D Touch will be responsed twice when the app is cold-launched

### DIFF
--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -25,7 +25,7 @@ NSDictionary *RNQuickAction(UIApplicationShortcutItem *item) {
 
 @implementation RNQuickActionManager
 {
-    UIApplicationShortcutItem *_initialAction;
+    NSDictionary *_shortcutItem;
 }
 
 RCT_EXPORT_MODULE();
@@ -59,7 +59,6 @@ RCT_EXPORT_MODULE();
 - (void)setBridge:(RCTBridge *)bridge
 {
     _bridge = bridge;
-    _initialAction = [bridge.launchOptions[UIApplicationLaunchOptionsShortcutItemKey] copy];
 }
 
 // Map user passed array of UIApplicationShortcutItem
@@ -155,14 +154,15 @@ RCT_EXPORT_METHOD(clearShortcutItems)
 
 - (void)handleQuickActionPress:(NSNotification *) notification
 {
+    _shortcutItem = notification.userInfo;
     [_bridge.eventDispatcher sendDeviceEventWithName:@"quickActionShortcut"
-                                                body:notification.userInfo];
+                                                body:_shortcutItem];
 }
 
 - (NSDictionary *)constantsToExport
 {
     return @{
-      @"initialAction": RCTNullIfNil(RNQuickAction(_initialAction))
+      @"initialAction": RCTNullIfNil(_shortcutItem)
     };
 }
 


### PR DESCRIPTION
like this:

```
QuickActions.popInitialAction().then(quickActionsHandler);
DeviceEventEmitter.addListener('quickActionShortcut', quickActionsHandler);
```

quickActionsHandler will be called twice